### PR TITLE
[bug|dev] add_help_parameter_with_extended_error_messages

### DIFF
--- a/include/ao_parameters.h
+++ b/include/ao_parameters.h
@@ -5,11 +5,17 @@ struct ao_parameters {
   unsigned char export;
   unsigned char play;
   char* path_export;
+
   unsigned char block;
+
   unsigned long int speed;
+  
   unsigned char synced_oscillator;
+  
   unsigned char visualizer;
   unsigned char visualizer_average;
+
+  unsigned char help;
 };
 
 int ao_parameters_parse(

--- a/sources/ao.c
+++ b/sources/ao.c
@@ -11,36 +11,96 @@
 #include <stdio.h>
 
 int main(
-  int count_parameters,
+  int length_parameters,
   char** parameters
 ) {
-  if (count_parameters < 2) {
-    ao_print_usage(1);
-
-    return 1;
-  }
-
   struct ao_parameters ao_parameters;
 
   int index_parameters_input = ao_parameters_parse(
     &ao_parameters,
-    count_parameters,
+    length_parameters,
     parameters
   );
 
-  if (index_parameters_input == -1) {
+  if (
+    ao_parameters.help == 1
+  ) {
+    ao_print_usage(0);
+
+    return 0;
+  }
+
+  if (
+    index_parameters_input < 0 ||
+    index_parameters_input >= length_parameters
+  ) {
+    int code_status_exit_error = 1;
+
+    if (
+      index_parameters_input == -1
+    ) {
+      fprintf(
+        stderr,
+        "must_provide_path_to_input_file_as_last_parameter\n"
+      );
+    } else if (
+      index_parameters_input >= length_parameters
+    ) {
+      fprintf(
+        stderr,
+        "invalid_value->{%s}.provided_for_parameter->{%s};\n",
+        parameters[
+          index_parameters_input -
+          length_parameters +
+          1
+        ],
+        parameters[
+          index_parameters_input -
+          length_parameters
+        ]
+      );
+
+      code_status_exit_error = 2;
+    } else {
+      fprintf(
+        stderr,
+        "unknown_parameter->{%s}\n",
+        parameters[
+          -(index_parameters_input + 2)
+        ]
+      );
+
+      code_status_exit_error = 3;
+    }
+
     ao_print_usage(1);
 
-    return 2;
+    return code_status_exit_error;
   }
-  
+
+  if (
+    index_parameters_input != length_parameters - 1
+  ) {
+    fprintf(
+      stderr,
+      "unknown_parameter->{%s};\n",
+      parameters[
+        index_parameters_input
+      ]
+    );
+
+    ao_print_usage(1);
+
+    return 3;
+  }
+
   struct aio_data aio_data;
   aio_data.initialized = 0;
 
   aio_data.mode = ao_parameters.export == 1 ? (
     ao_parameters.play == 1 ? export_play : export
   ) : play;
-  
+
   if (
     aio_data.mode == export ||
     aio_data.mode == export_play
@@ -60,7 +120,7 @@ int main(
   aio_data.visualizer_average = ao_parameters.visualizer_average;
 
   aio_data.length_file_inputs = (
-    count_parameters - index_parameters_input
+    length_parameters - index_parameters_input
   );
 
   aio_data.file_inputs = malloc(

--- a/sources/ao_parameters.c
+++ b/sources/ao_parameters.c
@@ -9,6 +9,7 @@ int ao_parameters_parse(
 ) {
   ao_parameters->block = 0;
   ao_parameters->export = 0;
+  ao_parameters->help = 0;
   ao_parameters->play = 0;
   ao_parameters->path_export = (void*)0;
   ao_parameters->speed = 1;
@@ -21,14 +22,34 @@ int ao_parameters_parse(
     index_parameter < length_parameters;
     ++index_parameter
   ) {
+    int index_parameter_valid = clic3_char_arrays_within(
+      parameters[index_parameter],
+      16,
+      "-o",
+      "-e",
+      "--export",
+      "--play",
+      "-v",
+      "--visualizer",
+      "-s",
+      "--speed",
+      "-b",
+      "--block",
+      "-x",
+      "--synchronize-oscillator",
+      "-a",
+      "--visualizer-average",
+      "-h",
+      "--help"
+    );
+
     if (
-      clic3_char_arrays_within(
-        parameters[index_parameter],
-        3,
-        "-o",
-        "-e",
-        "--export"
-      ) != -1
+      index_parameter_valid == -1
+    ) {
+      return index_parameter;
+    } else if (
+      index_parameter_valid >= 0 &&
+      index_parameter_valid <= 2
     ) {
       ao_parameters->export = 1;
 
@@ -39,42 +60,38 @@ int ao_parameters_parse(
       if (
         index_parameter >= length_parameters
       ) {
-        return -1;
+        return -2 - index_parameter;
       }
 
       ao_parameters->path_export = parameters[index_parameter];
     } else if (
-      clic3_char_arrays_within(
-        parameters[index_parameter],
-        1,
-        "--play"
-      ) != -1
+      index_parameter_valid == 3
     ) {
       ao_parameters->play = 1;
     } else if (
-      clic3_char_arrays_within(
-        parameters[index_parameter],
-        2,
-        "-v",
-        "--visualizer"
-      ) != -1
+      index_parameter_valid >= 4 &&
+      index_parameter_valid <= 5
     ) {
       ao_parameters->visualizer = 1;
     } else if (
-      clic3_char_arrays_within(
-        parameters[index_parameter],
-        2,
-        "-s",
-        "--speed"
-      ) != -1 &&
+      index_parameter_valid >= 6 &&
+      index_parameter_valid <= 7 &&
       index_parameter < (length_parameters - 1)
     ) {
       index_parameter = (
         index_parameter + 1
       );
 
+      if (
+        index_parameter >= length_parameters
+      ) {
+        return -2 - index_parameter;
+      }
+
       unsigned char status = clic3_char_array_to_unsigned_long_int(
-        parameters[index_parameter],
+        parameters[
+          index_parameter
+        ],
         &ao_parameters->speed
       );
 
@@ -82,37 +99,32 @@ int ao_parameters_parse(
         status != 0 ||
         ao_parameters->speed < 1
       ) {
-        return -1;
+        return (
+          length_parameters +
+          index_parameter -
+          1
+        );
       }
     } else if (
-      clic3_char_arrays_within(
-        parameters[index_parameter],
-        2,
-        "-b",
-        "--block"
-      ) != -1
+      index_parameter_valid >= 8 &&
+      index_parameter_valid <= 9
     ) {
       ao_parameters->block = 1;
     } else if (
-      clic3_char_arrays_within(
-        parameters[index_parameter],
-        2,
-        "-x",
-        "--synchronize-oscillator"
-      ) != -1
+      index_parameter_valid >= 10 &&
+      index_parameter_valid <= 11
     ) {
       ao_parameters->synced_oscillator = 1;
     } else if (
-      clic3_char_arrays_within(
-        parameters[index_parameter],
-        2,
-        "-a",
-        "--visualizer-average"
-      ) != -1
+      index_parameter_valid >= 12 &&
+      index_parameter_valid <= 13
     ) {
       ao_parameters->visualizer_average = 1;
-    } else {
-      return index_parameter;
+    } else if (
+      index_parameter_valid >= 14 &&
+      index_parameter_valid <= 15
+    ) {
+      ao_parameters->help = 1;
     }
   }
 

--- a/sources/ao_print_usage.c
+++ b/sources/ao_print_usage.c
@@ -15,13 +15,13 @@ void ao_print_usage(
     stream_output,
     "usage: ao [?parameters] [...paths_to_file_inputs]\n"
     "parameters:\n"
-    "  -o, -e, --export [output_path]\n"
-    "    --play : plays audio while exporting (default is no audio output when exporting)\n"
-    "  -b, --block : ceils and floors to maximum and minimum values\n"
-    "  -s, --speed [#1+] : the speed of file playback\n"
-    "  -x, --synchronize-oscillator : synchronizes oscillators to the speed value\n"
-    "  -v, --visualizer : displays an audio graph of the output\n"
-    "  -a, --visualize-average : averages the display output\n"
-    "  --help : displays usage information\n"
+    "  -o, -e, --export [output_path] : exports to a file\n"
+    "    --play                       : plays audio while exporting (default is no audio output when exporting)\n"
+    "  -b, --block                    : ceils and floors to maximum and minimum values\n"
+    "  -s, --speed [#1+]              : the speed of file playback\n"
+    "  -x, --synchronize_oscillator   : synchronizes oscillators to the speed value\n"
+    "  -v, --visualizer               : displays an audio graph of the output\n"
+    "  -a, --visualize_average        : averages the display output\n"
+    "  -h, --help                     : displays usage information\n"
   );
 }


### PR DESCRIPTION
- `ao_parameters`:
- - add_missing->{`help`};
- - refactor_parameter_parsing
- - add_extended_error_return_codes
- `ao`:
- - `count_parameters`->`length_parameters`
- - extended_error_messages
- `ao_print_usage`: align_output