### PR TITLE
[dev] Ensure variable naming consistency

### DIFF
--- a/sources/ao_parameters.c
+++ b/sources/ao_parameters.c
@@ -176,6 +176,23 @@ int ao_parameters_parse(
     }
   }
 
+  if (
+    ao_parameters->octave_minimum >
+    ao_parameters->octave_maximum
+  ) {
+    char octave_hold = (
+      ao_parameters->octave_minimum
+    );
+
+    ao_parameters->octave_minimum = (
+      ao_parameters->octave_maximum
+    );
+
+    ao_parameters->octave_maximum = (
+      octave_hold
+    );
+  }
+
   return (
     length_parameters -
     1


### PR DESCRIPTION
`cer0` swaps the places of these values anyways but this makes sure it's at least named correctly within `ao`