### PR TITLE
[doc] `readme.md`::octave parameter + `math_c` dependency documentation

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -27,9 +27,11 @@ parameters:
 
 ### libraries
 
-- [cer0](https://github.com/alic3dev/cer0)
-- [cexil](https://github.com/alic3dev/cexil)
-- [clic3](https://github.com/alic3dev/clic3)
+- [alic3dev](https://github.com/alic3dev)
+- - [`cer0`](https://github.com/alic3dev/cer0)
+- - [`cexil`](https://github.com/alic3dev/cexil)
+- - [`clic3`](https://github.com/alic3dev/clic3)
+- - [`math_c`](https://github.com/alic3dev/math_c)
 
 ## build
 

--- a/readme.md
+++ b/readme.md
@@ -10,6 +10,8 @@ parameters:
   -o, -e, --export [output_path] : exports to a file
     --play                       : plays audio while exporting (default is no audio output when exporting)
   -b, --block                    : ceils and floors to maximum and minimum values
+  --octave-minimum [#]           : sets the minimum octave
+  --octave-maximum [#]           : sets the maximum octave
   -s, --speed [#1+]              : the speed of file playback
   -x, --synchronize_oscillator   : synchronizes oscillators to the speed value
   -v, --visualizer               : displays an audio graph of the output


### PR DESCRIPTION
- `readme.md`:
- - add `math_c` dependency
- - add octave parameters information