### PR TITLE
[dev] Aio display cexil modifications threading

### DIFF
--- a/include/aio_display.h
+++ b/include/aio_display.h
@@ -1,11 +1,18 @@
 #ifndef __aio_display_h
 #define __aio_display_h
 
+#include <aio_display_thread.h>
+
 #include <cexil.h>
+
+#include <pthread.h>
 
 struct aio_display {
   struct cexil_renderer renderer;
   struct cexil_sprite sprite;
+
+  pthread_t thread;
+  struct aio_display_thread_data data_thread;
 
   unsigned int index_y_previous;
 };

--- a/include/aio_display_thread.h
+++ b/include/aio_display_thread.h
@@ -1,0 +1,36 @@
+#ifndef __aio_display_thread_h
+#define __aio_display_thread_h
+
+#include <pthread.h>
+
+struct aio_display_thread_data {
+  void* display;
+
+  float* queue;
+  unsigned int length_queue;
+
+  pthread_mutex_t mutex_queue;
+  pthread_mutex_t mutex_render;
+
+  unsigned char running;
+};
+
+void aio_display_thread_data_initialize(
+  struct aio_display_thread_data*,
+  void*
+);
+
+void aio_display_thread_queue_add(
+  struct aio_display_thread_data*,
+  float
+);
+
+void* aio_display_thread(
+  void*
+);
+
+void aio_display_thread_data_destroy(
+  struct aio_display_thread_data*
+);
+
+#endif

--- a/sources/aio.c
+++ b/sources/aio.c
@@ -1,6 +1,6 @@
 #include <aio.h>
 #include <aio_data.h>
-#include <aio_display.h>
+#include <aio_display_thread.h>
 #include <aio_export.h>
 #include <aio_frequency.h>
 #include <amplitude.h>
@@ -106,8 +106,8 @@ OSStatus aio(
           if (
             aio_data->visualizer_average == 0
           ) {
-            aio_display_update(
-              &aio_data->display,
+            aio_display_thread_queue_add(
+              &aio_data->display.data_thread,
               value_output
             );
           } else {
@@ -122,8 +122,8 @@ OSStatus aio(
                 )
               );
 
-              aio_display_update(
-                &aio_data->display,
+              aio_display_thread_queue_add(
+                &aio_data->display.data_thread,
                 value_output
               );
 
@@ -178,8 +178,8 @@ OSStatus aio(
           if (
             aio_data->visualizer != 0
           ) {
-            aio_display_render(
-              &aio_data->display
+            pthread_mutex_unlock(
+              &aio_data->display.data_thread.mutex_render
             );
           }
 
@@ -198,8 +198,8 @@ OSStatus aio(
   if (
     aio_data->visualizer != 0
   ) {
-    aio_display_render(
-      &aio_data->display
+    pthread_mutex_unlock(
+      &aio_data->display.data_thread.mutex_render
     );
   }
 

--- a/sources/aio_display.c
+++ b/sources/aio_display.c
@@ -1,5 +1,7 @@
 #include <aio_display.h>
 
+#include <aio_display_thread.h>
+
 #include <cexil.h>
 
 void aio_display_initialize(
@@ -26,7 +28,19 @@ void aio_display_initialize(
     &aio_display->sprite
   );
 
+  aio_display_thread_data_initialize(
+    &aio_display->data_thread,
+    aio_display
+  );
+
   aio_display->index_y_previous = 0;
+
+  pthread_create(
+    &aio_display->thread,
+    0,
+    aio_display_thread,
+    &aio_display->data_thread
+  );
 }
 
 void aio_display_update(
@@ -107,18 +121,33 @@ void aio_display_update(
 void aio_display_render(
   struct aio_display* aio_display
 ) {
-  cexil_renderer_render_clear(
-    &aio_display->renderer
-  );
-
-  cexil_renderer_render(
-    &aio_display->renderer
+  pthread_mutex_unlock(
+    &aio_display->data_thread.mutex_render
   );
 }
 
 void aio_display_destroy(
   struct aio_display* aio_display
 ) {
+  aio_display->data_thread.running = 0;
+
+  pthread_mutex_unlock(
+    &aio_display->data_thread.mutex_queue
+  );
+
+  pthread_mutex_unlock(
+    &aio_display->data_thread.mutex_render
+  );
+
+  pthread_join(
+    aio_display->thread,
+    0
+  );
+
+  aio_display_thread_data_destroy(
+    &aio_display->data_thread
+  );
+
   cexil_renderer_destroy(
     &aio_display->renderer
   );

--- a/sources/aio_display_thread.c
+++ b/sources/aio_display_thread.c
@@ -1,0 +1,181 @@
+#include <aio_display_thread.h>
+
+#include <aio_display.h>
+
+#include <clic3_bytes.h>
+#include <clic3_memory.h>
+
+#include <pthread.h>
+
+void aio_display_thread_data_initialize(
+  struct aio_display_thread_data* aio_display_thread_data,
+  void* display
+) {
+  aio_display_thread_data->display = display;
+
+  pthread_mutex_init(
+    &aio_display_thread_data->mutex_queue,
+    0
+  );
+
+  pthread_mutex_init(
+    &aio_display_thread_data->mutex_render,
+    0
+  );
+
+  aio_display_thread_data->length_queue = 0;
+  aio_display_thread_data->queue = (
+    clic3_memory_allocate_raw(
+      0
+    )
+  );
+
+  aio_display_thread_data->running = 1;
+}
+
+void aio_display_thread_queue_add(
+  struct aio_display_thread_data* aio_display_thread_data,
+  float frequency
+) {
+  pthread_mutex_lock(
+    &aio_display_thread_data->mutex_queue
+  );
+
+  aio_display_thread_data->length_queue = (
+    aio_display_thread_data->length_queue +
+    1
+  );
+
+  clic3_memory_reallocate_raw(
+    &aio_display_thread_data->queue,
+    (
+      sizeof(
+        float
+      ) *
+      aio_display_thread_data->length_queue
+    )
+  );
+
+  aio_display_thread_data->queue[
+    aio_display_thread_data->length_queue -
+    1
+  ] = (
+    frequency
+  );
+
+  pthread_mutex_unlock(
+    &aio_display_thread_data->mutex_queue
+  );
+}
+
+void* aio_display_thread(
+  void* data_thread
+) {
+  struct aio_display_thread_data* aio_display_thread_data = (
+    data_thread
+  );
+
+  struct aio_display* aio_display = (
+    aio_display_thread_data->display
+  );
+
+  while(
+    aio_display_thread_data->running == 1
+  ) {
+    pthread_mutex_lock(
+      &aio_display_thread_data->mutex_render
+    );
+
+    pthread_mutex_lock(
+      &aio_display_thread_data->mutex_queue
+    );
+
+    if (
+      aio_display_thread_data->running != 1
+    ) {
+      pthread_mutex_unlock(
+        &aio_display_thread_data->mutex_queue
+      );
+
+      pthread_mutex_unlock(
+        &aio_display_thread_data->mutex_render
+      );
+
+      break;
+    }
+
+    unsigned int length_queue_buffered = (
+      aio_display_thread_data->length_queue
+    );
+
+    float* queue_buffered = (
+      clic3_memory_allocate_raw(
+        sizeof(
+          float
+        ) *
+        length_queue_buffered
+      )
+    );
+
+    clic3_bytes_copy(
+      queue_buffered,
+      aio_display_thread_data->queue,
+      length_queue_buffered
+    );
+
+    aio_display_thread_data->length_queue = 0;
+    clic3_memory_reallocate_raw(
+      &aio_display_thread_data->queue,
+      0
+    );
+
+    pthread_mutex_unlock(
+      &aio_display_thread_data->mutex_queue
+    );
+
+    for (
+      unsigned int index_queue_buffered = 0;
+      index_queue_buffered < length_queue_buffered;
+      ++index_queue_buffered
+    ) {
+      aio_display_update(
+        aio_display,
+        queue_buffered[
+          index_queue_buffered
+        ]
+      );
+    }
+
+    clic3_memory_free_raw(
+      queue_buffered
+    );
+
+    cexil_renderer_render_clear(
+      &aio_display->renderer
+    );
+
+    cexil_renderer_render(
+      &aio_display->renderer
+    );
+  };
+
+  return (
+    0
+  );
+}
+
+void aio_display_thread_data_destroy(
+  struct aio_display_thread_data* aio_display_thread_data
+) {
+  clic3_memory_free_raw(
+    aio_display_thread_data->queue
+  );
+
+  pthread_mutex_destroy(
+    &aio_display_thread_data->mutex_render
+  );
+
+  pthread_mutex_destroy(
+    &aio_display_thread_data->mutex_queue
+  );
+}

--- a/sources/ao.c
+++ b/sources/ao.c
@@ -156,7 +156,9 @@ int main(
     (void*)0
   );
 
-  if (aio_data.visualizer != 0) {
+  if (
+    aio_data.visualizer != 0
+  ) {
     aio_display_initialize(
       &aio_data.display
     );


### PR DESCRIPTION
- `aio_display_thread`:add|implement
- - threads the display pipeline
- - prevents audio buffering "clicks" and breaks in the output
- - maintains consistent x:y axis


https://github.com/user-attachments/assets/bdb0b80e-897e-460e-a4b0-226b9fa41e64


here's some outputs with different combinations of `-v` and `-v -a`